### PR TITLE
[PLAT-7795] Update sbt version installed by setup_workstation

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,6 +1,6 @@
 ---
 sbt_playbook_version: "0.2.0"
-sbt_version: "0.13.18"
+sbt_version: "1.8.2"
 sbt_archive_name: "sbt-{{sbt_version}}"
 sbt_archive_file: "{{sbt_archive_name}}.tgz"
 sbt_url_prefix: "https://github.com/sbt/sbt/releases/download"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -5,7 +5,7 @@ sbt_archive_name: "sbt-{{sbt_version}}"
 sbt_archive_file: "{{sbt_archive_name}}.tgz"
 sbt_url_prefix: "https://github.com/sbt/sbt/releases/download"
 sbt_download_url: "{{ sbt_url_prefix }}/v{{ sbt_version }}/{{ sbt_archive_file }}"
-sbt_archive_checksum: "sha256:afe82322ca8e63e6f1e10fc1eb515eb7dc6c3e5a7f543048814072a03d83b331"
+sbt_archive_checksum: "sha256:1f65344da074dbd66dfefa93c0eff8d319d772e5cad47fcbeb6ae178bbdf4686"
 sbt_install_prefix: /usr/local
 sbt_lib_path: "{{ sbt_install_prefix }}/share/sbt"
 sbt_lib_path_target: "{{sbt_lib_path}}/{{sbt_version}}"


### PR DESCRIPTION
We've updated both play framework and JDK, and are using sbt 1.8.2 in YBA repo right now.
This is required to install appropriate SBT version for YBA development - even though old launcher can download required new SBT version - it's completely incompatible with JDK17 and fails to start with:
`Unrecognized VM option 'UseConcMarkSweepGC'`